### PR TITLE
Add Next.js todo skeleton with MongoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Todo App with Next.js, Tailwind CSS and MongoDB
+
+This is a simple Todo application with user registration and login built with Next.js. Tasks are stored in MongoDB.
+
+## Features
+
+- User registration and authentication with JSON Web Tokens
+- Create, toggle and delete todo items
+- Styled with Tailwind CSS
+
+## Setup
+
+1. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+2. Create a `.env.local` file and provide the following variables:
+   ```env
+   MONGODB_URI=your-mongodb-connection-string
+   JWT_SECRET=your-secret
+   ```
+3. Run the development server:
+   ```bash
+   npm run dev
+   ```
+4. Open `http://localhost:3000` in your browser.
+
+Due to the environment used to create this repository, dependencies are not installed automatically.

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose'
+
+const MONGODB_URI = process.env.MONGODB_URI
+
+if (!MONGODB_URI) {
+  throw new Error('Please define the MONGODB_URI environment variable inside .env.local')
+}
+
+let cached = global.mongoose
+
+if (!cached) {
+  cached = global.mongoose = { conn: null, promise: null }
+}
+
+async function dbConnect() {
+  if (cached.conn) return cached.conn
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(MONGODB_URI, {
+      bufferCommands: false,
+    }).then((mongoose) => mongoose)
+  }
+  cached.conn = await cached.promise
+  return cached.conn
+}
+
+export default dbConnect

--- a/models/Todo.js
+++ b/models/Todo.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose'
+
+const TodoSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  text: String,
+  completed: Boolean
+})
+
+export default mongoose.models.Todo || mongoose.model('Todo', TodoSchema)

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose'
+
+const UserSchema = new mongoose.Schema({
+  email: { type: String, unique: true, required: true },
+  password: { type: String, required: true }
+})
+
+export default mongoose.models.User || mongoose.model('User', UserSchema)

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "todo-next-mongo",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "mongodb": "latest",
+    "mongoose": "latest",
+    "tailwindcss": "latest",
+    "postcss": "latest",
+    "autoprefixer": "latest",
+    "bcryptjs": "latest",
+    "jsonwebtoken": "latest"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '@/styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,18 @@
+import dbConnect from '../../lib/db'
+import User from '../../models/User'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+
+const SECRET = process.env.JWT_SECRET || 'secret'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end()
+  await dbConnect()
+  const { email, password } = req.body
+  const user = await User.findOne({ email })
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' })
+  const isMatch = await bcrypt.compare(password, user.password)
+  if (!isMatch) return res.status(401).json({ message: 'Invalid credentials' })
+  const token = jwt.sign({ id: user._id }, SECRET)
+  res.status(200).json({ token })
+}

--- a/pages/api/register.js
+++ b/pages/api/register.js
@@ -1,0 +1,16 @@
+import dbConnect from '../../lib/db'
+import User from '../../models/User'
+import bcrypt from 'bcryptjs'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end()
+  await dbConnect()
+  const { email, password } = req.body
+  const hashed = await bcrypt.hash(password, 10)
+  try {
+    const user = await User.create({ email, password: hashed })
+    res.status(201).json({ id: user._id, email: user.email })
+  } catch (e) {
+    res.status(400).json({ message: 'User creation failed' })
+  }
+}

--- a/pages/api/todos.js
+++ b/pages/api/todos.js
@@ -1,0 +1,46 @@
+import dbConnect from '../../lib/db'
+import Todo from '../../models/Todo'
+import jwt from 'jsonwebtoken'
+
+const SECRET = process.env.JWT_SECRET || 'secret'
+
+async function auth(req) {
+  const { authorization } = req.headers
+  if (!authorization) return null
+  const [, token] = authorization.split(' ')
+  try {
+    return jwt.verify(token, SECRET)
+  } catch {
+    return null
+  }
+}
+
+export default async function handler(req, res) {
+  await dbConnect()
+  const user = await auth(req)
+  if (!user) return res.status(401).json({ message: 'Unauthorized' })
+
+  if (req.method === 'GET') {
+    const todos = await Todo.find({ userId: user.id })
+    return res.status(200).json(todos)
+  }
+
+  if (req.method === 'POST') {
+    const todo = await Todo.create({ userId: user.id, text: req.body.text, completed: false })
+    return res.status(201).json(todo)
+  }
+
+  if (req.method === 'PUT') {
+    const { id, completed } = req.body
+    const todo = await Todo.findByIdAndUpdate(id, { completed }, { new: true })
+    return res.status(200).json(todo)
+  }
+
+  if (req.method === 'DELETE') {
+    const { id } = req.body
+    await Todo.findByIdAndDelete(id)
+    return res.status(204).end()
+  }
+
+  res.status(405).end()
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,78 @@
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Home() {
+  const router = useRouter()
+  const [todos, setTodos] = useState([])
+  const [text, setText] = useState('')
+
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    if (!token) return router.push('/login')
+    fetch('/api/todos', {
+      headers: { Authorization: `Bearer ${token}` }
+    }).then(r => r.json()).then(setTodos)
+  }, [])
+
+  const addTodo = async (e) => {
+    e.preventDefault()
+    const token = localStorage.getItem('token')
+    const res = await fetch('/api/todos', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ text })
+    })
+    const todo = await res.json()
+    setTodos([...todos, todo])
+    setText('')
+  }
+
+  const toggleTodo = async (id, completed) => {
+    const token = localStorage.getItem('token')
+    const res = await fetch('/api/todos', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ id, completed })
+    })
+    const updated = await res.json()
+    setTodos(todos.map(t => t._id === id ? updated : t))
+  }
+
+  const deleteTodo = async (id) => {
+    const token = localStorage.getItem('token')
+    await fetch('/api/todos', {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ id })
+    })
+    setTodos(todos.filter(t => t._id !== id))
+  }
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h1 className="text-2xl mb-4">Todo List</h1>
+      <form onSubmit={addTodo} className="flex mb-4">
+        <input className="flex-1 border p-2" value={text} onChange={(e) => setText(e.target.value)} />
+        <button className="ml-2 px-4 py-2 bg-blue-500 text-white">Add</button>
+      </form>
+      <ul>
+        {todos.map(todo => (
+          <li key={todo._id} className="flex items-center mb-2">
+            <input type="checkbox" className="mr-2" checked={todo.completed} onChange={() => toggleTodo(todo._id, !todo.completed)} />
+            <span className={todo.completed ? 'line-through flex-1' : 'flex-1'}>{todo.text}</span>
+            <button className="ml-2 text-red-500" onClick={() => deleteTodo(todo._id)}>X</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Login() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const submit = async (e) => {
+    e.preventDefault()
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+    if (res.ok) {
+      const { token } = await res.json()
+      localStorage.setItem('token', token)
+      router.push('/')
+    }
+  }
+
+  return (
+    <div className="max-w-sm mx-auto p-4">
+      <h1 className="text-2xl mb-4">Login</h1>
+      <form onSubmit={submit} className="flex flex-col gap-2">
+        <input className="border p-2" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <input className="border p-2" type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        <button className="bg-blue-500 text-white p-2">Login</button>
+      </form>
+      <p className="mt-2">No account? <a href="/register" className="text-blue-500">Register</a></p>
+    </div>
+  )
+}

--- a/pages/register.js
+++ b/pages/register.js
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Register() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const submit = async (e) => {
+    e.preventDefault()
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+    if (res.ok) {
+      router.push('/login')
+    }
+  }
+
+  return (
+    <div className="max-w-sm mx-auto p-4">
+      <h1 className="text-2xl mb-4">Register</h1>
+      <form onSubmit={submit} className="flex flex-col gap-2">
+        <input className="border p-2" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <input className="border p-2" type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        <button className="bg-blue-500 text-white p-2">Register</button>
+      </form>
+      <p className="mt-2">Already have an account? <a href="/login" className="text-blue-500">Login</a></p>
+    </div>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- initialize Next.js skeleton with Tailwind CSS and MongoDB models
- add API routes for register/login/todos with JWT auth
- add simple pages for login, register, and todo list
- document setup instructions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686153c21cc0832a848d65f9a96de5a8